### PR TITLE
Reduce number of identical requests

### DIFF
--- a/lib/data_kitten.rb
+++ b/lib/data_kitten.rb
@@ -19,6 +19,7 @@ require 'data_kitten/temporal'
 require 'data_kitten/dataset'
 require 'data_kitten/distribution_format'
 require 'data_kitten/distribution'
+require 'data_kitten/fetcher'
 
 # A collection of classes that represent Datasets and other concepts, modeled on {http://www.w3.org/TR/vocab-dcat/ DCAT}.
 #

--- a/lib/data_kitten/dataset.rb
+++ b/lib/data_kitten/dataset.rb
@@ -28,8 +28,6 @@ module DataKitten
     # @!attribute access_url
     #   @return [String] the URL that gives access to the dataset
     attr_accessor :access_url
-    alias_method :uri, :access_url
-    alias_method :url, :access_url
 
     # Create a new Dataset object
     # 
@@ -38,10 +36,18 @@ module DataKitten
     #                                      The class will attempt to auto-load metadata from this URL.
     #
     def initialize(options)
-      @access_url = options[:access_url]
+      @access_url = DataKitten::Fetcher.wrap(options[:access_url])
       detect_origin
       detect_host
       detect_publishing_format
+    end
+
+    def uri
+      URI(@access_url.to_s)
+    end
+
+    def url
+      @access_url.to_s
     end
   
     # Can metadata be loaded for this Dataset?

--- a/lib/data_kitten/fetcher.rb
+++ b/lib/data_kitten/fetcher.rb
@@ -1,0 +1,70 @@
+module DataKitten
+
+  class Fetcher
+
+    attr_reader :url
+
+    def self.wrap(url_or_fetcher)
+      if url_or_fetcher.is_a?(self)
+        url_or_fetcher
+      else
+        new(url_or_fetcher)
+      end
+    end
+
+    def initialize(url)
+      @url = url
+    end
+
+    def ok?
+      code == 200
+    end
+
+    def code
+      response ? response.code : @code
+    end
+
+    def body
+      response if response
+    end
+
+    def as_json
+      JSON.parse(body) if response
+    rescue JSON::ParserError
+      nil
+    end
+
+    def content_type
+      response.headers[:content_type] if response
+    end
+
+    def content_type_format
+      if val = content_type
+        val.split(';').first
+      end
+    end
+
+    def to_s
+      url.to_s
+    end
+
+    def html?
+      !!(content_type_format =~ %r{^text/html}i)
+    end
+
+    private
+    def response
+      unless @requested
+        @requested = true
+        begin
+          @response = RestClient.get(url)
+        rescue RestClient::ExceptionWithResponse => error
+          @error = error.response
+          @code = @error.code
+        end
+      end
+      @response
+    end
+  end
+  
+end

--- a/lib/data_kitten/hosts.rb
+++ b/lib/data_kitten/hosts.rb
@@ -14,7 +14,8 @@ module DataKitten
         DataKitten::Hosts::Bitbucket,
         DataKitten::Hosts::Gist
       ].each do |host|
-        extend host if host.supported?(@access_url)
+        extend host if host.supported?(url)
+        break
       end
     end
 

--- a/lib/data_kitten/origins/git.rb
+++ b/lib/data_kitten/origins/git.rb
@@ -10,8 +10,8 @@ module DataKitten
   
       private
   
-      def self.supported?(uri)
-        uri =~ /\A(git|https?):\/\/.*\.git\Z/
+      def self.supported?(resource)
+        resource.to_s =~ /\A(git|https?):\/\/.*\.git\Z/
       end
 
       public

--- a/lib/data_kitten/origins/html.rb
+++ b/lib/data_kitten/origins/html.rb
@@ -10,10 +10,8 @@ module DataKitten
   
       private
   
-      def self.supported?(uri)
-        RestClient.get(uri).headers[:content_type] =~ /text\/html/
-      rescue
-          false
+      def self.supported?(resource)
+        resource.html?
       end
 
       public

--- a/lib/data_kitten/origins/linked_data.rb
+++ b/lib/data_kitten/origins/linked_data.rb
@@ -10,15 +10,10 @@ module DataKitten
   
       private
   
-      def self.supported?(uri)
-        content_type = RestClient.head(uri).headers[:content_type]
-        return nil unless content_type
-        
-        return RDF::Format.content_types.keys.include?( 
-            content_type.split(";").first )    
-            
-      rescue
-          false
+      def self.supported?(resource)
+        if type = resource.content_type_format
+          RDF::Format.content_types.keys.include?(type)
+        end
       end
 
       public

--- a/lib/data_kitten/publishing_formats/ckan.rb
+++ b/lib/data_kitten/publishing_formats/ckan.rb
@@ -9,7 +9,7 @@ module DataKitten
       private
 
       def self.supported?(instance)
-        uri = URI(instance.uri)
+        uri = instance.uri
         package = uri.path.split("/").last
         # If the package is a UUID - it's more than likely to be a CKAN ID
         if package.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)

--- a/lib/data_kitten/publishing_formats/ckan.rb
+++ b/lib/data_kitten/publishing_formats/ckan.rb
@@ -80,8 +80,9 @@ module DataKitten
       #
       # @see Dataset#licenses
       def licenses
-        uri = metadata["license_url"] || metadata["extras"]["licence_url"] rescue nil
-        name = metadata["license_title"] || metadata["extras"]["licence_url_title"] rescue nil
+        extras = metadata["extras"] || {}
+        uri = metadata["license_url"] || extras["licence_url"]
+        name = metadata["license_title"] || extras["licence_url_title"]
         [
           License.new(:id => metadata["license_id"],
                       :uri => uri,

--- a/lib/data_kitten/publishing_formats/datapackage.rb
+++ b/lib/data_kitten/publishing_formats/datapackage.rb
@@ -17,7 +17,7 @@ module DataKitten
             datapackage = DataPackage::Package.new( JSON.parse( metadata ) )
             return datapackage.datapackage_version != nil
           else
-            datapackage = DataPackage::Package.new( instance.uri )
+            datapackage = DataPackage::Package.new( instance.url )
             return datapackage.datapackage_version != nil
           end
         rescue => e
@@ -157,7 +157,7 @@ module DataKitten
             metadata = load_file("datapackage.json")
             @datapackage = DataPackage::Package.new( JSON.parse( metadata ) )
           else
-            @datapackage = DataPackage::Package.new( access_url )
+            @datapackage = DataPackage::Package.new( url )
           end        
         end
         @datapackage         

--- a/lib/data_kitten/publishing_formats/linked_data.rb
+++ b/lib/data_kitten/publishing_formats/linked_data.rb
@@ -26,7 +26,7 @@ module DataKitten
       #Supports content negotiation for various RDF serializations. Attempts "dataset autodiscovery" if it receives
       #an HTML response. This leaves the RDFa Publishing Format to just parse RDFa responses
       def self.create_graph(uri)
-        
+
         resp = RestClient.get uri, 
             :accept=>ACCEPT_HEADER            
         return false if resp.code != 200
@@ -55,15 +55,13 @@ module DataKitten
         graph << reader.new( StringIO.new( resp.body ))
                
         return graph     
-      rescue => e
-        #puts e
-        #puts e.backtrace
+      rescue
         nil
       end
 
       #Can we create an RDF graph for this object containing the description of a dataset?
       def self.supported?(instance)
-          graph = create_graph(instance.uri)
+          graph = create_graph(instance.url)
           return false unless graph
           return true if first_of_type(graph, 
               [RDF::Vocabulary.new("http://www.w3.org/ns/dcat#").Dataset, 
@@ -80,21 +78,14 @@ module DataKitten
         :rdf
       end
             
-      def uri
-        access_url
-      end
-      
       private
       
       def dataset_uri
-        access_url
+        url
       end
             
       def graph
-        if !@graph
-          @graph = LinkedData.create_graph(access_url)
-        end
-        @graph   
+        @graph ||= LinkedData.create_graph(dataset_uri)
       end
       
     end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe DataKitten::Fetcher do
+
+  before(:all) do
+    FakeWeb.clean_registry
+    FakeWeb.allow_net_connect = false
+  end
+
+  describe 'wrapping returns same instance' do
+    before do
+      FakeWeb.register_uri(:get, "http://example.org/resource", :body=> "<p>text</p>", :content_type=>"text/html; encoding=utf-8")
+    end
+    subject(:resource) { described_class.new("http://example.org/resource") }
+
+    it { should eq(DataKitten::Fetcher.wrap(resource)) }
+    it "should not request again" do
+      expect(resource).to be_ok
+      new_resource = DataKitten::Fetcher.wrap(resource)
+      FakeWeb.clean_registry
+      expect(new_resource).to be_ok
+    end
+  end
+
+  describe 'wrapping returns same instance' do
+    before do
+
+    end
+  end
+
+  describe 'present resource' do
+    before do
+      FakeWeb.register_uri(:get, "http://example.org/resource", :body=> "<p>text</p>", :content_type=>"text/html; encoding=utf-8")
+    end
+    subject(:resource) { described_class.new("http://example.org/resource") }
+
+    it { should be_ok }
+    it { expect(resource.code).to eq(200) }
+    it { expect(resource.body).to eq("<p>text</p>") }
+    it { expect(resource.as_json).to be_nil }
+    it { should be_html }
+    it { expect(resource.content_type).to eq("text/html; encoding=utf-8") }
+    it { expect(resource.content_type_format).to eq("text/html") }
+    it { expect(resource.to_s).to eq("http://example.org/resource") }
+  end
+
+  describe 'present json resource' do
+    before do
+      FakeWeb.register_uri(:get, "http://example.org/resource", :body=> '{"hi":"there"}', :content_type=>"application/json; encoding=utf-8")
+    end
+    subject(:resource) { described_class.new("http://example.org/resource") }
+
+    it { should be_ok }
+    it { expect(resource.code).to eq(200) }
+    it { should_not be_html }
+    it { expect(resource.as_json).to eq({"hi" => "there"}) }
+    it { expect(resource.content_type).to eq("application/json; encoding=utf-8") }
+    it { expect(resource.content_type_format).to eq("application/json") }
+    it { expect(resource.to_s).to eq("http://example.org/resource") }
+  end
+
+  describe 'not found' do
+    before do
+      FakeWeb.register_uri(:get, "http://example.org/not-found", :status => ["404", "Not Found"])
+    end
+    subject(:resource) { described_class.new("http://example.org/not-found") }
+
+    it { should_not be_ok }
+    it { expect(resource.code).to eq(404) }
+  end
+
+end

--- a/spec/origins/linked_data_spec.rb
+++ b/spec/origins/linked_data_spec.rb
@@ -5,13 +5,13 @@ describe DataKitten::Origins::LinkedData do
     context "when detecting origin" do
     
         it "should ignore errors" do       
-            FakeWeb.register_uri(:head, "http://example.org/not-found", :status => ["404", "Not Found"])            
+            FakeWeb.register_uri(:get, "http://example.org/not-found", :status => ["404", "Not Found"])            
             d = DataKitten::Dataset.new( access_url: "http://example.org/not-found")
             expect( d.origin ).to eql(nil)              
         end
         
         it "should support turtle" do
-            FakeWeb.register_uri(:head, "http://example.org/doc/dataset", :body=>"", :content_type=>"text/turtle") 
+            FakeWeb.register_uri(:get, "http://example.org/doc/dataset", :body=>"", :content_type=>"text/turtle") 
             d = DataKitten::Dataset.new( access_url: "http://example.org/doc/dataset")   
             expect( d.origin ).to eql(:linkeddata)                           
         end        

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -14,17 +14,17 @@ describe DataKitten::Dataset do
 
     it 'correctly identified https URLs' do
       r = DataKitten::Dataset.new(access_url: "https://github.com/theodi/github-viewer-test-data.git")
-      r.host.should == :github
+      expect(r.host).to eq(:github)
     end
     
     it 'correctly identified http URLs' do
       r = DataKitten::Dataset.new(access_url: "http://github.com/theodi/github-viewer-test-data.git")
-      r.host.should == :github
+      expect(r.host).to eq(:github)
     end
     
     it 'correctly identified git URLs' do
       r = DataKitten::Dataset.new(access_url: "git://github.com/theodi/github-viewer-test-data.git")
-      r.host.should == :github
+      expect(r.host).to eq(:github)
     end
 
   end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -6,10 +6,6 @@ describe DataKitten::Dataset do
     @r = DataKitten::Dataset.new(access_url: "http://github.com/theodi/github-viewer-test-data.git")
   end
 
-  # it "can generate a stripped version of the uri for descriptions and links" do
-  #   @r.stripped_uri.should == 'github.com/theodi/github-viewer-test-data'
-  # end
-
   context 'with data on github' do
 
     it 'correctly identified https URLs' do


### PR DESCRIPTION
The various tests make huge number of identical responses.

Wrap the url in a response caching object that can get passed around. It behaves as a combination of the response and the url.