### PR TITLE
Add license abbreviation

### DIFF
--- a/lib/data_kitten/license.rb
+++ b/lib/data_kitten/license.rb
@@ -3,6 +3,23 @@ module DataKitten
   # A license for a {Dataset} or {Distribution}
   #
   class License
+    
+    LICENSES = {
+      /opendatacommons.org.*\/by(\/|$)/ => "odc-by",
+      /opendatacommons.org.*\/odbl(\/|$)/ => "odc-odbl",
+      /opendatacommons.org.*\/pddl(\/|$)/ => "odc-pddl",
+      /opendefinition.org.*\/odc-by(\/|$)/ => "odc-by",
+      /opendefinition.org.*\/odc-pddl(\/|$)/ => "odc-pddl",
+      /opendefinition.org.*\/cc-zero(\/|$)/ => "cc-zero",
+      /opendefinition.org.*\/cc-by(\/|$)/ => "cc-by",
+      /opendefinition.org.*\/cc-by-sa(\/|$)/ => "cc-by-sa",
+      /opendefinition.org.*\/gfdl(\/|$)/ => "gfdl",
+      /creativecommons.org.*\/zero(\/|$)/ => "cc-zero",
+      /creativecommons.org.*\/by-sa(\/|$)/ => "cc-by-sa",
+      /creativecommons.org.*\/by(\/|$)/ => "cc-by",
+      /(data|nationalarchives).gov.uk.*\/open-government-licence(\/|$)/ => "ogl-uk",
+      /usa.gov\/publicdomain(\/|$)/ => "us-pd"
+    }
 
     # @!attribute is
     #   @return [String] a short ID that identifies the license.
@@ -19,6 +36,10 @@ module DataKitten
     # @!attribute type
     #   @return [String] the type of information this license applies to. Could be +:data+ or +:content+.
     attr_accessor :type
+    
+    # @!attribute abbr
+    #   @return [String] the license abbreviation
+    attr_accessor :abbr
 
     # Create a new License object.
     #
@@ -32,6 +53,12 @@ module DataKitten
       @name = options[:name]
       @uri = options[:uri]
       @type = options[:type]
+      @abbr = get_license_abbr(@uri) if @uri
+    end
+    
+    def get_license_abbr(uri)
+      license = LICENSES.find { |regex, abbr| uri =~ regex }
+      license.last if license
     end
 
   end  

--- a/spec/license_spec.rb
+++ b/spec/license_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe DataKitten::License do
+
+  describe 'with known licenses' do
+    
+    known_licenses = {
+      "http://www.opendefinition.org/licenses/cc-by" => "cc-by",
+      "http://www.opendefinition.org/licenses/cc-by/" => "cc-by",
+      "http://www.opendefinition.org/licenses/cc-by-sa" => "cc-by-sa",
+      "http://www.opendefinition.org/licenses/gfdl" => "gfdl",
+      "http://www.opendefinition.org/licenses/odc-pddl" => "odc-pddl",
+      "http://www.opendefinition.org/licenses/cc-zero" => "cc-zero",
+      "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" => "ogl-uk",
+      "http://reference.data.gov.uk/id/open-government-licence" => "ogl-uk"
+    }
+    
+    it 'should supply abbreviation' do
+      known_licenses.each do |uri, abbr|
+        expect(described_class.new(:uri => uri).abbr).to eq(abbr)
+      end
+    end
+  end
+  
+  describe 'with an unknown license' do
+    it 'should not provide an abbreviation' do
+      expect(described_class.new(:uri => "http://made-up-cc-by-sa.com/cc-by").abbr).to be_nil
+    end
+  end
+
+end


### PR DESCRIPTION
If a license URI is one of the known URIs it exposes an abbreviation.
This makes it easier to detect some of the common licenses, since URIs
can be different but refer to the same license.