### PR TITLE
Use CKAN base URI to construct publisher URLs

### DIFF
--- a/lib/data_kitten/dataset.rb
+++ b/lib/data_kitten/dataset.rb
@@ -282,6 +282,7 @@ module DataKitten
     end
 
     attr_accessor :metadata
+    attr_accessor :base_uri
 
   end
 end

--- a/lib/data_kitten/publishing_formats/ckan.rb
+++ b/lib/data_kitten/publishing_formats/ckan.rb
@@ -35,6 +35,7 @@ module DataKitten
         instance.metadata = JSON.parse RestClient.get base_uri.merge("api/rest/package/#{instance.identifier}").to_s
         instance.metadata.extend(GuessableLookup)
         instance.source = instance.metadata
+        instance.base_uri = base_uri
         return true
       rescue
         false

--- a/lib/data_kitten/publishing_formats/ckan.rb
+++ b/lib/data_kitten/publishing_formats/ckan.rb
@@ -253,14 +253,13 @@ module DataKitten
       end
 
       def fetch_publisher(id)
-        uri = parsed_uri
         [
-          "#{uri.scheme}://#{uri.host}/api/3/action/organization_show?id=#{id}",
-          "#{uri.scheme}://#{uri.host}/api/3/action/group_show?id=#{id}",
-          "#{uri.scheme}://#{uri.host}/api/rest/group/#{id}"
+          base_uri.merge("/api/3/action/organization_show?id=#{id}"),
+          base_uri.merge("/api/3/action/group_show?id=#{id}"),
+          base_uri.merge("/api/rest/group/#{id}")
         ].each do |uri|
           begin
-            @group = JSON.parse RestClient.get uri
+            @group = JSON.parse RestClient.get(uri.to_s)
             break
           rescue
             # FakeWeb raises FakeWeb::NetConnectNotAllowedError, whereas 

--- a/spec/dataset_spec.rb
+++ b/spec/dataset_spec.rb
@@ -36,6 +36,12 @@ describe DataKitten::Dataset do
       dataset = DataKitten::Dataset.new("http://example.org/dataset/defence")
       expect(dataset.source).to eql(data)
     end
+
+    it 'returns the ckan base_uri' do
+      url = CKANFakeweb.register_defence_dataset
+      dataset = DataKitten::Dataset.new("http://example.org/dataset/defence")
+      expect(dataset.base_uri).to eql(URI("http://example.org/"))
+    end
   end
 
   describe 'with an unsupported format' do


### PR DESCRIPTION
Fixes #92. Stores the CKAN `base_uri` on `DataKitten::Dataset` so it can be used to construct the publisher URLs.